### PR TITLE
[WIP]Feature/installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ An element identifier helps to tell RPA for Python exactly which element on the 
 #### CORE FUNCTIONS
 Function|Parameters|Purpose
 :-------|:---------|:------
-init()|visual_automation = False, chrome_browser = True|start TagUI, auto-setup on first run
+init()|visual_automation = False, chrome_browser = True, installation_dir = "path"|start TagUI, auto-setup on first run
 close()||close TagUI, Chrome browser, SikuliX
 pack()||for deploying package without internet
 update()||for updating package without internet
 
 >_to print and log debug info to rpa_python.log use debug(True), to switch off use debug(False)_
+>_to set custome installation path use r.init(installation_dir="/home/user/opt/.tagui")_
 
 #### BASIC FUNCTIONS
 Function|Parameters|Purpose

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Function|Parameters|Purpose
 :-------|:---------|:------
 init()|visual_automation = False, chrome_browser = True, installation_dir = "path"|start TagUI, auto-setup on first run
 close()||close TagUI, Chrome browser, SikuliX
-pack()||for deploying package without internet
-update()|installation_dir = "path"|for updating package without internet
+pack()|installation_dir = "path"|for deploying package without internet
+update()||for updating package without internet
 
 >_to print and log debug info to rpa_python.log use debug(True), to switch off use debug(False)._
 >_to set custome installation path use r.init(installation_dir="/home/user/opt/.tagui")._

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Function|Parameters|Purpose
 init()|visual_automation = False, chrome_browser = True, installation_dir = "path"|start TagUI, auto-setup on first run
 close()||close TagUI, Chrome browser, SikuliX
 pack()||for deploying package without internet
-update()||for updating package without internet
+update()|installation_dir = "path"|for updating package without internet
 
->_to print and log debug info to rpa_python.log use debug(True), to switch off use debug(False)_
->_to set custome installation path use r.init(installation_dir="/home/user/opt/.tagui")_
+>_to print and log debug info to rpa_python.log use debug(True), to switch off use debug(False)._
+>_to set custome installation path use r.init(installation_dir="/home/user/opt/.tagui")._
 
 #### BASIC FUNCTIONS
 Function|Parameters|Purpose

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RPA for Python :snake:
 
-[**Use Cases**](#use-cases)&ensp;|&ensp;[**API Reference**](#api-reference)&ensp;|&ensp;[**About & Credits**](#about--credits)&ensp;|&ensp;[**PyCon Video**](https://www.youtube.com/watch?v=F2aQKWx_EAE)&ensp;|&ensp;[**v1.27**](https://github.com/tebelorg/RPA-Python/releases)
+[**v1.36**](https://github.com/tebelorg/RPA-Python/releases)&ensp;|&ensp;[**Use Cases**](#use-cases)&ensp;|&ensp;[**API Reference**](#api-reference)&ensp;|&ensp;[**About & Credits**](#about--credits)&ensp;|&ensp;[**PyCon Video**](https://www.youtube.com/watch?v=F2aQKWx_EAE)&ensp;|&ensp;[**Run in Colab**](https://colab.research.google.com/drive/13bQO6G_hzE1teX35a3NZ4T5K-ICFFdB5?usp=sharing)&ensp;|&ensp;[**Telegram Chat**](https://t.me/rpa_chat)
 
->_This tool was previously known as TagUI for Python. [More details](https://github.com/tebelorg/RPA-Python/issues/100) on the name change, which is backward compatible so existing scripts written with `import tagui as t` and `t.function()` will continue to work._
+>_This tool was previously known as TagUI for Python. [More details](https://github.com/tebelorg/RPA-Python/issues/100) on the name change, which is backward compatible so existing scripts written with `import tagui as t` and `t.function()` will still work._
 
 ![RPA for Python demo in Jupyter notebook](https://raw.githubusercontent.com/tebelorg/Tump/master/tagui_python.gif)
 
@@ -23,7 +23,7 @@ Notes on different operating systems and optional visual automation mode -
 
 # Use Cases
 
-RPA for Python's simple and powerful API makes robotic process automation fun! You can use it to quickly automate repetitive time-consuming tasks, whether the tasks involve websites, desktop applications, or the command line.
+RPA for Python's simple and powerful API makes robotic process automation fun! You can use it to quickly automate away repetitive time-consuming tasks on websites, desktop applications, or the command line.
 
 #### WEB AUTOMATION&ensp;:spider_web:
 ```python
@@ -62,7 +62,7 @@ r.init(visual_automation = True, chrome_browser = False)
 r.keyboard('[cmd][space]')
 r.keyboard('safari[enter]')
 r.keyboard('[cmd]t')
-r.keyboard('joker[enter]')
+r.keyboard('mortal kombat[enter]')
 r.wait(2.5)
 r.snap('page.png', 'results.png')
 r.close()
@@ -73,8 +73,8 @@ r.close()
 r.init(visual_automation = True)
 r.type(600, 300, 'open source')
 r.click(900, 300)
-r.snap('page.bmp', 'results.bmp')
-r.hover('button_to_drag.bmp')
+r.snap('page.png', 'results.png')
+r.hover('button_to_drag.png')
 r.mouse('down')
 r.hover(r.mouse_x() + 300, r.mouse_y())
 r.mouse('up')
@@ -83,7 +83,7 @@ r.close()
 
 # API Reference
 
-Check out [sample Python script](https://github.com/tebelorg/RPA-Python/blob/master/sample.py), [RPA Challenge solution](https://github.com/tebelorg/RPA-Python/issues/120#issuecomment-610518196), and [RedMart groceries example](https://github.com/tebelorg/RPA-Python/issues/24). To automate Chrome browser invisibly, see this [simple hack](https://github.com/tebelorg/RPA-Python/issues/133#issuecomment-634113838). To run 20-30X faster, without normal UI interaction delays, [see this advanced hack](https://github.com/tebelorg/RPA-Python/issues/120#issuecomment-610532082).
+See [sample Python script](https://github.com/tebelorg/RPA-Python/blob/master/sample.py), the [RPA Challenge solution](https://github.com/tebelorg/RPA-Python/issues/120#issuecomment-610518196), and [RedMart groceries example](https://github.com/tebelorg/RPA-Python/issues/24). To automate Chrome browser invisibly, use [headless_mode](https://github.com/tebelorg/RPA-Python#core-functions). To run 20-30X faster, without normal UI interaction delays, [see this hack](https://github.com/tebelorg/RPA-Python/issues/120#issuecomment-610532082). You can even run on your phone browser [using this Colab notebook](https://colab.research.google.com/drive/13bQO6G_hzE1teX35a3NZ4T5K-ICFFdB5?usp=sharing) (eg datascraping in headless mode).
 
 #### ELEMENT IDENTIFIERS
 An element identifier helps to tell RPA for Python exactly which element on the user interface you want to interact with. For example, //\*[@id="email"] is an XPath pointing to the webpage element having the id attribute "email".
@@ -97,13 +97,13 @@ An element identifier helps to tell RPA for Python exactly which element on the 
 #### CORE FUNCTIONS
 Function|Parameters|Purpose
 :-------|:---------|:------
-init()|visual_automation = False, chrome_browser = True, installation_dir = "path"|start TagUI, auto-setup on first run
+init()|visual_automation = False, chrome_browser = True|start TagUI, auto-setup on first run
 close()||close TagUI, Chrome browser, SikuliX
-pack()|installation_dir = "path"|for deploying package without internet
+pack()||for deploying package without internet
 update()||for updating package without internet
+debug()|True or False|print & log debug info to rpa_python.log
 
->_to print and log debug info to rpa_python.log use debug(True), to switch off use debug(False)._
->_to set custome installation path use r.init(installation_dir="/home/user/opt/.tagui")._
+>_by default Chrome runs with visible mode, to run Chrome invisibly use init(headless_mode = True)_
 
 #### BASIC FUNCTIONS
 Function|Parameters|Purpose
@@ -142,7 +142,7 @@ vision()|command_to_run (Python code for SikuliX)|run custom SikuliX commands
 timeout()|timeout_in_seconds (blank returns current timeout)|change wait timeout (default 10s)
 
 keyboard() modifiers and special keys -
->_[shift] [ctrl] [alt] [cmd] [win] [meta] [clear] [space] [enter] [backspace] [tab] [esc] [up] [down] [left] [right] [pageup] [pagedown] [delete] [home] [end] [insert] [f1] .. [f15] [printscreen] [scrolllock] [pause] [capslock] [numlock]_
+>_[shift] [ctrl] [alt] [win] [cmd] [clear] [space] [enter] [backspace] [tab] [esc] [up] [down] [left] [right] [pageup] [pagedown] [delete] [home] [end] [insert] [f1] .. [f15] [printscreen] [scrolllock] [pause] [capslock] [numlock]_
 
 #### HELPER FUNCTIONS
 Function|Parameters|Purpose
@@ -158,19 +158,19 @@ title()||return page title of current web page as string
 text()||return text content of current web page as string
 timer()||return time elapsed in sec between calls as float
 
->_to type large amount of text quickly, use clipboard() and keyboard() to paste instead of type()_
+>_to type a large amount of text quickly, use clipboard() and keyboard() to paste instead of type()_
 
 # About & Credits
 
-TagUI is the leading open-source RPA software :robot: with thousands of active users. It was created in 2016-2017 when I left DBS Bank as a test automation engineer, to embark on a one-year sabbatical to Eastern Europe. Most of its code base was written in Novi Sad Serbia. My wife and I also spent a couple of months in Budapest Hungary, as well as Chiang Mai Thailand for visa runs. In 2018, I joined AI Singapore to continue development of TagUI.
+TagUI is a leading open-source RPA software :robot: with tens of thousands of users. It was created in 2016-2017 when I left DBS Bank as a test automation engineer, to embark on a one-year sabbatical to Eastern Europe. Most of its code base was written in Novi Sad Serbia. My wife and I also spent a couple of months in Budapest Hungary, as well as Chiang Mai Thailand for visa runs. In 2018, I joined AI Singapore to continue development of TagUI.
 
-Over the past few months I take on a daddy role full-time, taking care of my newborn baby girl and wife :cowboy_hat_face:🤱. In between the nannying, I use my time pockets to create this Python package that's built on TagUI. I hope that RPA for Python and ML frameworks would be good friends, and `pip install rpa` would make life easier for Python users.
+Over the past few months I take on a daddy role full-time, taking care of my newborn baby girl and wife :cowboy_hat_face:🤱. In between nannying, I use my time pockets to create this Python package built on TagUI. I hope that RPA for Python and ML frameworks would be good friends, and `pip install rpa` would make life easier for Python users.
 
-Lastly, at only ~1k lines of code, it would make my day to see developers of other languages port this project over to their favourite programming language. See ample comments in this [single-file package](https://github.com/tebelorg/RPA-Python/blob/master/tagui.py), and its intuitive architecture -
+At only ~1k lines of code, it would make my day to see developers of other languages port this project over to their favourite programming language. See ample comments in this [single-file package](https://github.com/tebelorg/RPA-Python/blob/master/tagui.py), and its intuitive architecture.
 
 ![RPA for Python architecture](https://raw.githubusercontent.com/tebelorg/Tump/master/TagUI-Python/architecture.png)
 
-I would like to credit and express my appreciation below :bowing_man:, and you are invited to [connect on LinkedIn](https://www.linkedin.com/in/kensoh) -
+I would like to credit and express my appreciation below :heart:, and you are invited to [connect on LinkedIn](https://www.linkedin.com/in/kensoh) -
 
 - [TagUI](https://github.com/kelaberetiv/TagUI/tree/pre_v6) - AI Singapore from Singapore / [@aisingapore](https://www.aisingapore.org)
 - [SikuliX](https://github.com/RaiMan/SikuliX1) - Raimund Hocke from Germany / [@RaiMan](https://github.com/RaiMan)

--- a/tagui.py
+++ b/tagui.py
@@ -259,6 +259,9 @@ def setup(installation_dir = None):
     # override home folder when manual path is set
     if installation_dir:
         home_directory = installation_dir
+        # Check if directory exists, if not create one
+        if not os.path.isdir(home_directory):
+            os.mkdir(home_directory)
 
     print('[RPA][INFO] - setting up TagUI for use in your Python environment')
 
@@ -309,12 +312,16 @@ def setup(installation_dir = None):
     # set correct tagui folder for different operating systems
     if platform.system() == 'Windows':
         tagui_directory = home_directory + '/' + 'tagui'
+
+    elif installation_dir:
+        # copy content to parent folder
+        from distutils.dir_util import copy_tree, remove_tree
+        tagui_directory = home_directory
+        copy_tree(home_directory + '/' + 'tagui', home_directory)
+        remove_tree(home_directory + '/' + 'tagui')
+
     else:
         tagui_directory = home_directory + '/' + '.tagui'
-
-    # override with custom dir
-    if installation_dir:
-        tagui_directory = installation_dir + '/' + '.tagui'
 
         # overwrite tagui to .tagui folder for Linux / macOS
 
@@ -473,7 +480,7 @@ def init(visual_automation = False, chrome_browser = True, installation_dir = No
             tagui_directory = installation_dir
         else:
             print('[RPA][ERROR] - Please use path with target directory name tagui.')
-            sys.exit(1)
+            return False
 
     tagui_executable = tagui_directory + '/' + 'src' + '/' + 'tagui'
     end_processes_executable = tagui_directory + '/' + 'src' + '/' + 'end_processes'
@@ -615,7 +622,7 @@ def pack(installation_dir = None):
         print('[RPA][INFO] - It was detected to use a custom directory as source for packing.')
         if not os.path.isdir(installation_dir + "/src"):
             print('[RPA][ERROR] - Your target destination is not a valid path.')
-            sys.exit(1)
+            return False
 
     # first make sure TagUI files have been downloaded and synced to latest stable delta files
     global _tagui_started
@@ -717,7 +724,8 @@ if len(sys.argv) == 2:
             sys.exit(1)
     else:
         print('[RPA][ERROR] - Your target destination is not a valid path.')
-      
+        sys.exit(1)
+
 # unzip update.zip to tagui folder in target directory
 r.unzip('update.zip', base_directory + '/src')
 if os.path.isfile('update.zip'): os.remove('update.zip')

--- a/tagui.py
+++ b/tagui.py
@@ -247,11 +247,18 @@ def unzip(file_to_unzip = None, unzip_location = None):
     zip_file.close()
     return True
 
-def setup(installation_dir):
+def setup(installation_dir = None):
     """function to setup TagUI to user home folder on Linux / macOS / Windows"""
 
-    # set directory to setup tagui
-    home_directory = installation_dir
+    # get user home folder location to setup tagui
+    if platform.system() == 'Windows':
+        home_directory = os.environ['APPDATA']
+    else:
+        home_directory = os.path.expanduser('~')
+
+    # override home folder when manual path is set
+    if installation_dir:
+        home_directory = installation_dir
 
     print('[RPA][INFO] - setting up TagUI for use in your Python environment')
 
@@ -304,6 +311,10 @@ def setup(installation_dir):
         tagui_directory = home_directory + '/' + 'tagui'
     else:
         tagui_directory = home_directory + '/' + '.tagui'
+
+    # override with custome dir
+    if installation_dir:
+        tagui_directory = installation_dir + '/' + '.tagui'
 
         # overwrite tagui to .tagui folder for Linux / macOS
 
@@ -457,7 +468,7 @@ def init(visual_automation = False, chrome_browser = True, installation_dir = No
 
     # override home folder when manual path is set
     if installation_dir:
-        tagui_directory = installation_dir
+        tagui_directory = installation_dir + '/' + '.tagui'
 
     tagui_executable = tagui_directory + '/' + 'src' + '/' + 'tagui'
     end_processes_executable = tagui_directory + '/' + 'src' + '/' + 'end_processes'

--- a/tagui.py
+++ b/tagui.py
@@ -247,14 +247,11 @@ def unzip(file_to_unzip = None, unzip_location = None):
     zip_file.close()
     return True
 
-def setup():
+def setup(installation_dir):
     """function to setup TagUI to user home folder on Linux / macOS / Windows"""
 
-    # get user home folder location to setup tagui
-    if platform.system() == 'Windows':
-        home_directory = os.environ['APPDATA']
-    else:
-        home_directory = os.path.expanduser('~')
+    # set directory to setup tagui
+    home_directory = installation_dir
 
     print('[RPA][INFO] - setting up TagUI for use in your Python environment')
 
@@ -437,7 +434,7 @@ def setup():
 
     return True
 
-def init(visual_automation = False, chrome_browser = True):
+def init(visual_automation = False, chrome_browser = True, installation_dir = None):
     """start and connect to tagui process by checking tagui live mode readiness"""
 
     global _process, _tagui_started, _tagui_id, _tagui_visual, _tagui_chrome, _tagui_init_directory
@@ -458,12 +455,16 @@ def init(visual_automation = False, chrome_browser = True):
     else:
         tagui_directory = os.path.expanduser('~') + '/' + '.tagui'
 
+    # override home folder when manual path is set
+    if installation_dir:
+        tagui_directory = installation_dir
+
     tagui_executable = tagui_directory + '/' + 'src' + '/' + 'tagui'
     end_processes_executable = tagui_directory + '/' + 'src' + '/' + 'end_processes'
 
     # if tagui executable is not found, initiate setup() to install tagui
     if not os.path.isfile(tagui_executable):
-        if not setup():
+        if not setup(installation_dir):
             # error message is shown by setup(), no need for message here
             return False
 


### PR DESCRIPTION
Hello kensoh,

thanks for this great library. I like it a lot and it works like a charm to automate my stuff.
I had a idea for a feature, maybe it can help to improve your library.

## Idea

When I first was playing around with the library, I was wondering where tagui will be installed. After some runs I found the default home path for my system. I started to tinker around how to customize it. To be for example fhs compliant or help users with a space in their username.(#198)

I tinkered the parameter installation_dir to the init function in order to set the absolute installation path. So if someone do not want to use the default path, they would be able to change it.

## Example
Change installation target to /home/fi-do/opt/tagui instead of /home/fi-do/.tagui:
`r.init(installation_dir="/home/fi-do/opt/tagui)`
Pack with custom installation path:
`r.pack(installation_dir="/home/fi-do/opt/tagui")`
Update with custom installation path:
`python update.py "/home/fi-do/opt/tagui"`

All the best,
fi-do